### PR TITLE
Fix typos in quick-start.mdx

### DIFF
--- a/packages/docs/content/docs/getting-started/quick-start.mdx
+++ b/packages/docs/content/docs/getting-started/quick-start.mdx
@@ -44,8 +44,8 @@ This command starts the Motia runtime and the Workbench, a powerful UI for devel
 The starter project comes with a pre-built `basic-tutorial` flow. Let's run it.
 
 1.  **Open the Workbench** in your browser at [`http://localhost:3000`](http://localhost:3000).
-2.  **Click the  the `Tutorial`** button on the top right of the workbnech.
-3.  **Complete the  the `Tutorial`** to get an understanding of the basica of Motia and using the Workbench.
+2.  **Click the `Tutorial`** button on the top right of the workbnech.
+3.  **Complete the `Tutorial`** to get an understanding of the basics of Motia and using the Workbench.
 
 ![run starter app](/docs-images/motia-build-your-app.gif)
 


### PR DESCRIPTION
Corrected typos in the quick-start documentation.